### PR TITLE
feat: implement payment engine lite mvp

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+on:
+  push: { branches: ["main"] }
+  pull_request: {}
+jobs:
+  build_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 20 }
+      - run: npm ci
+      - run: npm run build
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# payment-engine-mvp
+# Payment Engine Lite (MVP, funcional, multi-cloud)
+
+**Stack:** Node.js + TypeScript (funcional), OpenTelemetry → Datadog, CloudEvents 1.0, Ports/Adapters.
+
+## Quickstart (local)
+```bash
+docker compose -f infra/docker-compose.yml up
+# API en :3000
+curl -s -XPOST 'http://localhost:3000/payments?mode=sync' \
+  -H 'Content-Type: application/json' -H 'Idempotency-Key: inv-1' \
+  -d '{"originId":"originA","idempotencyKey":"inv-1","amount":1299,"currency":"USD","orderId":"ord-1","capture":false,"token":{"type":"network","token":"tok_x"}}' | jq
+```
+
+## Tests
+```bash
+npm i
+npm test
+```
+
+Repo estructura:
+- `apps/api` HTTP
+- `apps/workers` consumidores de eventos
+- `packages/*` domain, ports, adapters, gateways, lib, tests
+- `infra/docker-compose.yml` Datadog Agent opcional
+- `openapi.yaml`
+
+Notas:
+- Idempotencia por Idempotency-Key (header/body)
+- Token-only (PCI MVP)
+- Gateways intercambiables vía OriginPolicy
+- Reemplaza adapters in-memory por reales para producción

--- a/apps/api/src/app.ts
+++ b/apps/api/src/app.ts
@@ -1,0 +1,112 @@
+import express from "express";
+import { randomUUID } from "crypto";
+import { z } from "zod";
+import { CreatePaymentRequest, CreateRefundRequest, Payment } from "@domain/schemas";
+import { memoryConfig, memorySeedOrigin } from "@adapters/configs/memory";
+import { inMemoryBus } from "@adapters/messagebus/inMemory";
+import { idempotencyMiddleware } from "@lib/idempotency";
+import { makeGateway } from "@lib/originRouter";
+import { shape } from "@lib/responseShaper";
+import { startOTel } from "@lib/otel";
+
+const otel = startOTel();
+
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+
+// redact tokens in logs/outputs
+const redact = (s: any) => JSON.parse(JSON.stringify(s, (k, v) => (k === "token" ? "[REDACTED]" : v)));
+
+const store = memoryConfig();
+const bus = inMemoryBus();
+
+// seed origin policy for local dev
+memorySeedOrigin({
+  originId: "originA",
+  locale: "es-EC",
+  currency: "USD",
+  responseShape: { omit: ["authCode"], rename: { paymentId: "id" }, mapStatus: { authorized: "approved" } },
+  gatewaySelector: { type: "static", value: "mock" },
+  fraudRules: {},
+  retryProfile: { strategy: "exponential", maxAttempts: 6, baseDelayMs: 200 },
+  webhooks: {},
+  queueType: "standard",
+});
+
+const idem = idempotencyMiddleware(store);
+
+app.post("/payments", async (req, res) => {
+  const mode = (req.query.mode as string) ?? "async";
+  const idk = (req.headers["idempotency-key"] as string) || req.body.idempotencyKey;
+  if (!idk) return res.status(422).json({ error: "Idempotency-Key required" });
+
+  const parsed = CreatePaymentRequest.safeParse(req.body);
+  if (!parsed.success) return res.status(422).json({ error: parsed.error.flatten() });
+  const body = parsed.data;
+
+  const policy = await store.getOriginPolicy(body.originId);
+  if (!policy) return res.status(422).json({ error: "Unknown originId" });
+
+  const exec = async () => {
+    const paymentId = randomUUID();
+    const now = new Date().toISOString();
+    const gateway = makeGateway(policy);
+    if (mode === "sync") {
+      const auth = await gateway.authorize(body);
+      let status: Payment["status"] = auth.ok ? "authorized" : "failed";
+      const p: Payment = { paymentId, status, amount: body.amount, currency: body.currency, originId: body.originId, gateway: gateway.name, authCode: auth.ok ? auth.authCode : null, createdAt: now, updatedAt: now };
+      await store.putPayment(p);
+      const shaped = shape(p, policy.responseShape);
+      return { code: auth.ok ? 201 : 422, body: shaped };
+    } else {
+      const ev = {
+        specversion: "1.0",
+        id: randomUUID(),
+        type: "PaymentRequested",
+        source: "payment-engine-lite/api",
+        time: now,
+        data: { paymentId, request: { ...body, token: { ...body.token, token: "[REDACTED]" } }, originId: body.originId, idempotencyKey: idk },
+      };
+      await store.outboxAdd(ev as any);
+      await bus.publish("payments.requested", ev);
+      const resp = { paymentId, status: "accepted", traceId: req.headers["x-trace-id"] ?? "" };
+      return { code: 202, body: resp };
+    }
+  };
+
+  const { hit, result } = await idem(idk, exec);
+  if (hit) return res.status(409).json({ idempotency: "hit", result });
+  const { code, body } = result as any;
+  return res.status(code).json(redact(body));
+});
+
+app.get("/payments/:id", async (req, res) => {
+  const p = await store.getPayment(req.params.id);
+  if (!p) return res.status(404).json({ error: "not_found" });
+  return res.json(p);
+});
+
+app.post("/refunds", async (req, res) => {
+  const idk = (req.headers["idempotency-key"] as string) || req.body.idempotencyKey;
+  if (!idk) return res.status(422).json({ error: "Idempotency-Key required" });
+  const parsed = CreateRefundRequest.safeParse(req.body);
+  if (!parsed.success) return res.status(422).json({ error: parsed.error.flatten() });
+  const exec = async () => {
+    const ev = { specversion: "1.0", id: randomUUID(), type: "RefundRequested", source: "payment-engine-lite/api", time: new Date().toISOString(), data: parsed.data };
+    await store.outboxAdd(ev as any);
+    await bus.publish("refunds.requested", ev);
+    return { code: 202, body: { status: "accepted" } };
+  };
+  const { result } = await idem(idk, exec);
+  const { code, body } = result as any;
+  return res.status(code).json(body);
+});
+
+app.post("/webhooks/gateway", async (_req, res) => res.status(204).end());
+
+export const server = app;
+if (require.main === module) {
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => console.log(`API on :${port}`));
+  process.on("SIGINT", async () => { await otel.shutdown(); process.exit(0); });
+}

--- a/apps/workers/src/paymentsWorker.ts
+++ b/apps/workers/src/paymentsWorker.ts
@@ -1,0 +1,31 @@
+import { inMemoryBus } from "@adapters/messagebus/inMemory";
+import { memoryConfig } from "@adapters/configs/memory";
+import { makeGateway } from "@lib/originRouter";
+import { Payment } from "@domain/schemas";
+
+const bus = inMemoryBus();
+const store = memoryConfig();
+
+const handler = async (ev: any) => {
+  const { paymentId, request, originId, idempotencyKey } = ev.data;
+  const policy = await store.getOriginPolicy(originId);
+  if (!policy) return;
+  const gateway = makeGateway(policy);
+  const auth = await gateway.authorize(request);
+  const now = new Date().toISOString();
+  const status: Payment["status"] = auth.ok ? "authorized" : "failed";
+  await store.putPayment({
+    paymentId, status, amount: request.amount, currency: request.currency, originId, gateway: gateway.name,
+    authCode: auth.ok ? auth.authCode : null, createdAt: now, updatedAt: now,
+  });
+  await bus.publish("payments.processed", {
+    specversion: "1.0", id: paymentId, type: auth.ok ? "PaymentAuthorized" : "PaymentFailed",
+    source: "payment-engine-lite/worker", time: now, data: { paymentId, originId, idempotencyKey },
+  });
+};
+
+export const start = async () => {
+  await bus.subscribe!("payments.requested", handler);
+  console.log("paymentsWorker subscribed");
+};
+if (require.main === module) start();

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,36 @@
+version: "3.9"
+services:
+  api:
+    image: node:20
+    working_dir: /app
+    command: bash -lc "npm i && npm run dev:api"
+    ports: ["3000:3000"]
+    environment:
+      SERVICE_NAME: api
+      DD_ENV: dev
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://dd-agent:4318/v1/traces
+      OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: http://dd-agent:4318/v1/metrics
+    volumes:
+      - ../:/app
+    depends_on: [dd-agent]
+  workers:
+    image: node:20
+    working_dir: /app
+    command: bash -lc "npm i && npm run dev:workers"
+    environment:
+      SERVICE_NAME: workers
+      DD_ENV: dev
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: http://dd-agent:4318/v1/traces
+      OTEL_EXPORTER_OTLP_METRICS_ENDPOINT: http://dd-agent:4318/v1/metrics
+    volumes:
+      - ../:/app
+    depends_on: [dd-agent]
+  dd-agent:
+    image: gcr.io/datadoghq/agent:latest
+    environment:
+      DD_SITE: datadoghq.com
+      DD_API_KEY: ${DD_API_KEY:-invalid}
+      DD_LOGS_ENABLED: "true"
+      DD_APM_ENABLED: "true"
+      DD_DOGSTATSD_NON_LOCAL_TRAFFIC: "true"
+    ports: ["8126:8126", "4317:4317", "4318:4318"]

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,85 @@
+openapi: 3.1.0
+info:
+  title: Payment Engine Lite
+  version: 0.1.0
+servers:
+  - url: http://localhost:3000
+paths:
+  /payments:
+    post:
+      summary: Create a payment (authorize/capture)
+      parameters:
+        - in: query
+          name: mode
+          schema: { type: string, enum: [sync, async], default: async }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePaymentRequest'
+      responses:
+        '201': { description: Created }
+        '202': { description: Accepted }
+        '409': { description: Idempotency hit }
+        '422': { description: Validation error }
+  /payments/{id}:
+    get:
+      summary: Get a payment status
+      parameters:
+        - in: path
+          name: id
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: Found }
+        '404': { description: Not found }
+  /refunds:
+    post:
+      summary: Create a refund
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateRefundRequest'
+      responses:
+        '201': { description: Refund complete (sync) }
+        '202': { description: Refund accepted (async) }
+  /webhooks/gateway:
+    post:
+      summary: Receive gateway callbacks (simulados/mock)
+      responses:
+        '204': { description: Acknowledged }
+components:
+  schemas:
+    Token:
+      type: object
+      properties:
+        type: { type: string, enum: [network, vault] }
+        token: { type: string }
+        brand: { type: string }
+        last4: { type: string }
+        expMonth: { type: integer }
+        expYear: { type: integer }
+    CreatePaymentRequest:
+      type: object
+      required: [originId, idempotencyKey, amount, currency, orderId, token]
+      properties:
+        originId: { type: string }
+        idempotencyKey: { type: string }
+        amount: { type: integer, description: "minor units" }
+        currency: { type: string }
+        orderId: { type: string }
+        capture: { type: boolean, default: false }
+        token: { $ref: '#/components/schemas/Token' }
+        metadata: { type: object, additionalProperties: true }
+    CreateRefundRequest:
+      type: object
+      required: [originId, idempotencyKey, paymentId, amount]
+      properties:
+        originId: { type: string }
+        idempotencyKey: { type: string }
+        paymentId: { type: string }
+        amount: { type: integer }
+        metadata: { type: object }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "payment-engine-lite",
+  "private": true,
+  "version": "0.1.0",
+  "workspaces": ["apps/*", "packages/*"],
+  "scripts": {
+    "dev:api": "ts-node-dev --respawn -r tsconfig-paths/register apps/api/src/app.ts",
+    "dev:workers": "ts-node-dev --respawn -r tsconfig-paths/register apps/workers/src/paymentsWorker.ts",
+    "build": "tsc -b",
+    "test": "jest -c packages/tests/jest.config.ts",
+    "lint": "eslint . || true"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "zod": "^3.23.8",
+    "@opentelemetry/api": "^1.8.0",
+    "@opentelemetry/sdk-node": "^0.52.1",
+    "@opentelemetry/resources": "^1.8.0",
+    "@opentelemetry/semantic-conventions": "^1.25.1",
+    "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",
+    "@opentelemetry/exporter-metrics-otlp-http": "^0.52.1",
+    "@opentelemetry/sdk-metrics": "^1.10.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.5.4",
+    "ts-node-dev": "^2.0.0",
+    "ts-jest": "^29.2.4",
+    "jest": "^29.7.0",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.12",
+    "tsconfig-paths": "^4.2.0"
+  }
+}

--- a/packages/adapters/configs/memory.ts
+++ b/packages/adapters/configs/memory.ts
@@ -1,0 +1,23 @@
+import type { ConfigStorePort } from "@ports/configStorePort";
+import type { Payment, CloudEvent, OriginPolicy } from "@domain/schemas";
+
+const payments = new Map<string, Payment>();
+const idem = new Map<string, any>();
+const outbox: CloudEvent[] = [];
+const origins = new Map<string, OriginPolicy>();
+
+export const memoryConfig = (): ConfigStorePort => ({
+  getOriginPolicy: async (originId) => origins.get(originId) ?? null,
+  putPayment: async (p) => { payments.set(p.paymentId, p); },
+  getPayment: async (id) => payments.get(id) ?? null,
+  saveIdempotency: async (k, resp, _ttl) => {
+    if (idem.has(k)) return false;
+    idem.set(k, resp); return true;
+  },
+  getIdempotency: async (k) => idem.get(k) ?? null,
+  outboxAdd: async (ev) => { outbox.push(ev); },
+  outboxPullBatch: async (max) => outbox.splice(0, max),
+  outboxDelete: async (_ids) => { /* no-op for memory */ },
+});
+
+export const memorySeedOrigin = (p: OriginPolicy) => { origins.set(p.originId, p); };

--- a/packages/adapters/messagebus/inMemory.ts
+++ b/packages/adapters/messagebus/inMemory.ts
@@ -1,0 +1,17 @@
+import type { MessageBusPort, PublishOptions } from "@ports/messageBusPort";
+
+type Sub = { topic: string; handlers: ((p: any) => Promise<void>)[] };
+const subs: Sub[] = [];
+
+export const inMemoryBus = (): MessageBusPort => ({
+  publish: async (topic: string, payload: unknown, _opts?: PublishOptions) => {
+    const s = subs.find(s => s.topic === topic);
+    if (!s) return;
+    for (const h of s.handlers) await h(payload);
+  },
+  subscribe: async (subscription: string, handler: (p: any) => Promise<void>) => {
+    let s = subs.find(s => s.topic === subscription);
+    if (!s) { s = { topic: subscription, handlers: [] }; subs.push(s); }
+    s.handlers.push(handler);
+  },
+});

--- a/packages/domain/src/schemas.ts
+++ b/packages/domain/src/schemas.ts
@@ -1,0 +1,93 @@
+import { z } from "zod";
+
+export const Token = z.object({
+  type: z.enum(["network", "vault"]),
+  token: z.string().min(1),
+  brand: z.string().optional(),
+  last4: z.string().min(4).max(4).optional(),
+  expMonth: z.number().int().min(1).max(12).optional(),
+  expYear: z.number().int().min(2024).max(2100).optional(),
+});
+
+export const CreatePaymentRequest = z.object({
+  originId: z.string().min(1),
+  idempotencyKey: z.string().min(1),
+  amount: z.number().int().positive(),
+  currency: z.string().length(3),
+  orderId: z.string().min(1),
+  capture: z.boolean().default(false),
+  token: Token,
+  metadata: z.record(z.any()).optional(),
+});
+export type CreatePaymentRequest = z.infer<typeof CreatePaymentRequest>;
+
+export const PaymentStatus = z.enum(["requested", "authorized", "settled", "failed"]);
+export type PaymentStatus = z.infer<typeof PaymentStatus>;
+
+export const Payment = z.object({
+  paymentId: z.string(),
+  status: PaymentStatus,
+  amount: z.number().int(),
+  currency: z.string(),
+  originId: z.string(),
+  gateway: z.string().optional(),
+  authCode: z.string().nullable().optional(),
+  createdAt: z.string(),
+  updatedAt: z.string(),
+});
+export type Payment = z.infer<typeof Payment>;
+
+export const CreateRefundRequest = z.object({
+  originId: z.string(),
+  idempotencyKey: z.string(),
+  paymentId: z.string(),
+  amount: z.number().int().positive(),
+  metadata: z.record(z.any()).optional(),
+});
+export type CreateRefundRequest = z.infer<typeof CreateRefundRequest>;
+
+export const CloudEvent = z.object({
+  specversion: z.literal("1.0"),
+  id: z.string(),
+  type: z.string(),
+  source: z.string(),
+  subject: z.string().optional(),
+  datacontenttype: z.string().default("application/json"),
+  time: z.string(),
+  traceparent: z.string().optional(),
+  data: z.record(z.any()),
+});
+export type CloudEvent = z.infer<typeof CloudEvent>;
+
+export const RetryProfile = z.object({
+  strategy: z.enum(["exponential", "fixed"]).default("exponential"),
+  maxAttempts: z.number().int().min(0).default(6),
+  baseDelayMs: z.number().int().min(0).default(200),
+});
+export type RetryProfile = z.infer<typeof RetryProfile>;
+
+export const ResponseShape = z.object({
+  omit: z.array(z.string()).default([]),
+  rename: z.record(z.string()).default({}),
+  mapStatus: z.record(z.string()).default({}),
+});
+export type ResponseShape = z.infer<typeof ResponseShape>;
+
+export const OriginPolicy = z.object({
+  originId: z.string(),
+  locale: z.string().default("en-US"),
+  currency: z.string().length(3),
+  responseShape: ResponseShape.default({ omit: [], rename: {}, mapStatus: {} }),
+  gatewaySelector: z.object({
+    type: z.enum(["static", "byAmount", "byCurrency"]).default("static"),
+    value: z.string().default("mock"),
+  }),
+  fraudRules: z.record(z.any()).default({}),
+  retryProfile: RetryProfile.default({}),
+  webhooks: z.object({
+    url: z.string().url().optional(),
+    auth: z.string().optional(),
+  }).default({}),
+  queueType: z.enum(["standard", "fifo"]).default("standard"),
+});
+export type OriginPolicy = z.infer<typeof OriginPolicy>;

--- a/packages/gateways/mock.ts
+++ b/packages/gateways/mock.ts
@@ -1,0 +1,12 @@
+import type { GatewayPort } from "@ports/gatewayPort";
+import type { CreatePaymentRequest, CreateRefundRequest } from "@domain/schemas";
+
+export const MockGateway = (): GatewayPort => ({
+  name: "mock",
+  authorize: async (req: CreatePaymentRequest) => {
+    if (req.amount > 10000) return { ok: false as const, reason: "limit_exceeded" };
+    return { ok: true as const, authCode: "AUTH-MOCK-12345" };
+  },
+  capture: async (_paymentId: string) => ({ ok: true as const, settlementId: "SETTLE-MOCK-1" }),
+  refund: async (_req: CreateRefundRequest) => ({ ok: true as const, refundId: "REFUND-MOCK-1" }),
+});

--- a/packages/lib/src/idempotency.ts
+++ b/packages/lib/src/idempotency.ts
@@ -1,0 +1,10 @@
+import type { ConfigStorePort } from "@ports/configStorePort";
+
+export const idempotencyMiddleware = (store: ConfigStorePort) =>
+  async <T>(key: string, compute: () => Promise<T>, ttlSec = 24 * 3600): Promise<{hit:boolean; result:T}> => {
+    const hit = await store.getIdempotency(key);
+    if (hit) return { hit: true, result: hit as T };
+    const res = await compute();
+    const saved = await store.saveIdempotency(key, res, ttlSec);
+    return { hit: !saved, result: res };
+  };

--- a/packages/lib/src/originRouter.ts
+++ b/packages/lib/src/originRouter.ts
@@ -1,0 +1,11 @@
+import type { OriginPolicy } from "@domain/schemas";
+import type { GatewayPort } from "@ports/gatewayPort";
+import { MockGateway } from "@gateways/mock";
+
+export const makeGateway = (policy: OriginPolicy): GatewayPort => {
+  const name = policy.gatewaySelector.value.toLowerCase();
+  switch (name) {
+    case "mock": return MockGateway();
+    default: return MockGateway();
+  }
+};

--- a/packages/lib/src/otel.ts
+++ b/packages/lib/src/otel.ts
@@ -1,0 +1,31 @@
+import { diag, DiagConsoleLogger, DiagLogLevel } from "@opentelemetry/api";
+import { NodeSDK } from "@opentelemetry/sdk-node";
+import { Resource } from "@opentelemetry/resources";
+import { SemanticResourceAttributes } from "@opentelemetry/semantic-conventions";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http";
+import { OTLPMetricExporter } from "@opentelemetry/exporter-metrics-otlp-http";
+import { PeriodicExportingMetricReader } from "@opentelemetry/sdk-metrics";
+
+export const startOTel = () => {
+  try {
+    diag.setLogger(new DiagConsoleLogger(), DiagLogLevel.WARN);
+    const service = process.env.SERVICE_NAME ?? "payment-engine-lite";
+    const env = process.env.DD_ENV ?? process.env.NODE_ENV ?? "dev";
+    const resource = new Resource({
+      [SemanticResourceAttributes.SERVICE_NAME]: service,
+      [SemanticResourceAttributes.DEPLOYMENT_ENVIRONMENT]: env,
+      "service.version": process.env.SERVICE_VERSION ?? "0.1.0",
+    });
+    const sdk = new NodeSDK({
+      resource,
+      traceExporter: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT ? new OTLPTraceExporter({ url: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }) : undefined,
+      metricReader: process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT ? new PeriodicExportingMetricReader({
+        exporter: new OTLPMetricExporter({ url: process.env.OTEL_EXPORTER_OTLP_METRICS_ENDPOINT }),
+      }) : undefined,
+    });
+    sdk.start();
+    return sdk;
+  } catch {
+    return { shutdown: async () => {} } as any;
+  }
+};

--- a/packages/lib/src/responseShaper.ts
+++ b/packages/lib/src/responseShaper.ts
@@ -1,0 +1,13 @@
+import type { ResponseShape } from "@domain/schemas";
+
+export const shape = <T extends Record<string, any>>(obj: T, s: ResponseShape): any => {
+  let out: Record<string, any> = { ...obj };
+  for (const k of s.omit ?? []) delete out[k];
+  for (const [from, to] of Object.entries(s.rename ?? {})) {
+    if (from in out) { out[to] = out[from]; delete out[from]; }
+  }
+  if (out.status && s.mapStatus && (s.mapStatus as any)[out.status]) {
+    out.status = (s.mapStatus as any)[out.status];
+  }
+  return out;
+};

--- a/packages/ports/src/configStorePort.ts
+++ b/packages/ports/src/configStorePort.ts
@@ -1,0 +1,12 @@
+import type { OriginPolicy, Payment, CloudEvent } from "@domain/schemas";
+
+export type ConfigStorePort = {
+  getOriginPolicy: (originId: string) => Promise<OriginPolicy | null>;
+  putPayment: (pmt: Payment) => Promise<void>;
+  getPayment: (paymentId: string) => Promise<Payment | null>;
+  saveIdempotency: (key: string, response: any, ttlSec: number) => Promise<boolean>;
+  getIdempotency: (key: string) => Promise<any | null>;
+  outboxAdd: (event: CloudEvent) => Promise<void>;
+  outboxPullBatch: (max: number) => Promise<CloudEvent[]>;
+  outboxDelete: (ids: string[]) => Promise<void>;
+};

--- a/packages/ports/src/gatewayPort.ts
+++ b/packages/ports/src/gatewayPort.ts
@@ -1,0 +1,12 @@
+import type { CreatePaymentRequest, CreateRefundRequest } from "@domain/schemas";
+
+export type AuthorizationResult = { ok: true; authCode: string } | { ok: false; reason: string };
+export type CaptureResult = { ok: true; settlementId: string } | { ok: false; reason: string };
+export type RefundResult = { ok: true; refundId: string } | { ok: false; reason: string };
+
+export type GatewayPort = {
+  name: string;
+  authorize: (req: CreatePaymentRequest) => Promise<AuthorizationResult>;
+  capture: (paymentId: string) => Promise<CaptureResult>;
+  refund: (req: CreateRefundRequest) => Promise<RefundResult>;
+};

--- a/packages/ports/src/loggerPort.ts
+++ b/packages/ports/src/loggerPort.ts
@@ -1,0 +1,5 @@
+export type LoggerPort = {
+  info: (msg: string, meta?: Record<string, any>) => void;
+  warn: (msg: string, meta?: Record<string, any>) => void;
+  error: (msg: string, meta?: Record<string, any>) => void;
+};

--- a/packages/ports/src/messageBusPort.ts
+++ b/packages/ports/src/messageBusPort.ts
@@ -1,0 +1,11 @@
+export type PublishOptions = {
+  fifo?: boolean;
+  messageGroupId?: string;
+  messageDeduplicationId?: string;
+  attributes?: Record<string, string>;
+};
+export type MessageBusPort = {
+  publish: (topic: string, payload: unknown, opts?: PublishOptions) => Promise<void>;
+  subscribe?: (subscription: string, handler: (payload: any) => Promise<void>) => Promise<void>;
+  ack?: (ctx: unknown) => Promise<void>;
+};

--- a/packages/ports/src/metricsPort.ts
+++ b/packages/ports/src/metricsPort.ts
@@ -1,0 +1,5 @@
+export type MetricsPort = {
+  increment: (name: string, tags?: string[], value?: number) => void;
+  gauge: (name: string, value: number, tags?: string[]) => void;
+  timing: (name: string, ms: number, tags?: string[]) => void;
+};

--- a/packages/ports/src/objectStorePort.ts
+++ b/packages/ports/src/objectStorePort.ts
@@ -1,0 +1,4 @@
+export type ObjectStorePort = {
+  put: (bucket: string, key: string, body: Buffer | string) => Promise<void>;
+  get: (bucket: string, key: string) => Promise<Buffer | null>;
+};

--- a/packages/ports/src/secretStorePort.ts
+++ b/packages/ports/src/secretStorePort.ts
@@ -1,0 +1,1 @@
+export type SecretStorePort = { get: (key: string) => Promise<string | undefined> };

--- a/packages/tests/gatewayContract.test.ts
+++ b/packages/tests/gatewayContract.test.ts
@@ -1,0 +1,6 @@
+import { MockGateway } from "@gateways/mock";
+test("GatewayPort contract - authorize happy path", async () => {
+  const gw = MockGateway();
+  const ok = await gw.authorize({ amount: 100, currency: "USD", originId:"o", idempotencyKey:"i", orderId:"ord", capture:false, token:{type:"network", token:"t"} } as any);
+  expect(ok.ok).toBe(true);
+});

--- a/packages/tests/idempotency.test.ts
+++ b/packages/tests/idempotency.test.ts
@@ -1,0 +1,12 @@
+import { memoryConfig } from "@adapters/configs/memory";
+import { idempotencyMiddleware } from "@lib/idempotency";
+
+test("idempotency returns hit on second call", async () => {
+  const store = memoryConfig();
+  const idem = idempotencyMiddleware(store);
+  const exec = () => Promise.resolve({ ok: true });
+  const r1 = await idem("k1", exec);
+  const r2 = await idem("k1", exec);
+  expect(r1.hit).toBe(false);
+  expect(r2.hit).toBe(true);
+});

--- a/packages/tests/jest.config.ts
+++ b/packages/tests/jest.config.ts
@@ -1,0 +1,1 @@
+export default { testEnvironment: "node", transform: { "^.+\\.tsx?$": ["ts-jest", {}] } };

--- a/packages/tests/responseShaper.test.ts
+++ b/packages/tests/responseShaper.test.ts
@@ -1,0 +1,5 @@
+import { shape } from "@lib/responseShaper";
+test("shape renames and omits", () => {
+  const out = shape({ a: 1, b: 2, status: "authorized" }, { omit: ["b"], rename: { a: "x" }, mapStatus: { authorized: "approved" } } as any);
+  expect(out).toEqual({ x: 1, status: "approved" });
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "target": "ES2022",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "baseUrl": ".",
+    "paths": {
+      "@domain/*": ["packages/domain/src/*"],
+      "@ports/*": ["packages/ports/src/*"],
+      "@adapters/*": ["packages/adapters/*"],
+      "@gateways/*": ["packages/gateways/*"],
+      "@lib/*": ["packages/lib/src/*"]
+    },
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.base.json",
+  "include": ["apps/**/*", "packages/**/*"]
+}


### PR DESCRIPTION
## Summary
- add functional payment engine API with async workers and idempotency
- define domain schemas, ports, adapters, and mock gateway
- include tests, OpenAPI spec, and local docker-compose with Datadog agent

## Testing
- `npm install` *(failed: 403 Forbidden - GET https://registry.npmjs.org/@opentelemetry%2fapi)*
- `npm test` *(failed: sh: 1: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a232b4754c832187083f7408eea777